### PR TITLE
Increase test coverage in osparc and other minor fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,14 @@ install-dev: ## installs package in editable mode
 
 .PHONY: test-dev
 test-dev: ## runs tests
-	pytest --cov=./src -vv --pdb tests/
+	pytest \
+		--cov=./src \
+		-vv \
+		--pdb \
+		--cov-append \
+		--cov-report=term-missing \
+		--cov-report=xml \
+		tests/
 
 
 .PHONY: clean clean-venv clean-hooks

--- a/docs/sparc.client.services.rst
+++ b/docs/sparc.client.services.rst
@@ -4,7 +4,7 @@ sparc.client.services package
 Submodules
 ----------
 
-sparc.client.services.o2parc module
+sparc.client.services.o2sparc module
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: sparc.client.services.o2sparc

--- a/src/sparc/client/services/o2sparc.py
+++ b/src/sparc/client/services/o2sparc.py
@@ -20,11 +20,6 @@ class O2SparcService(ServiceBase):
         logging.info("Initializing o2sparc...")
         logging.debug("%s", f"{config=}")
 
-        # reuse
-        profile_name = config.get("pennsieve_profile_name", "prod")
-        if profile_name not in ["prod", "test", "ci"]:
-            raise ValueError(f"Invalid {profile_name=}.")
-
         kwargs = {}
         for name in ("host", "username", "password"):
             env_name = f"O2SPARC_{name.upper()}"
@@ -34,6 +29,9 @@ class O2SparcService(ServiceBase):
                 kwargs[name] = value
 
         configuration = osparc.Configuration(**kwargs)
+
+        # reuses profile-name from penssieve to set debug mode
+        profile_name = config.get("pennsieve_profile_name", "prod")
         configuration.debug = profile_name == "test"
 
         self._client = osparc.ApiClient(configuration=configuration)


### PR DESCRIPTION
Addresses test-coverage failure in [main's CI](https://app.codecov.io/gh/nih-sparc/sparc.client/commit/797fa2630da08ce0313f2236dde566019e809e4f) and other minor fixes:
- Increases test coverage of osparc module to 100%
- Minor adjustments in makefile to visualize coverage report
- Fixes typo in doc https://github.com/nih-sparc/sparc.client/pull/17#discussion_r1259111183


NOTE to repo owners:
- It would be desirable to have a test-coverage job also in the pull-request CI. This way we can note any issue **before** the pull-request gets merged to `main`.
- I would like to suggest to configure the reponsitory so that "squash" is enforced when merging pull-requests to the `main` branch (see [doc](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/configuring-commit-squashing-for-pull-requests) ). I did not notice last time and all my individual commits ended up in `main`  which IMO added unnecessary noise to the history of this branch.