### PR TITLE
Change to support Python 3.9

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -36,6 +36,7 @@ jobs:
         path: 'docs/_build/html'
 
   deploy:
+    if: github.repository == 'nih-sparc/sparc.client'
     # Add a dependency to the build job
     needs: build
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # CHANGELOG
 
+## [v0.3.0] - 2024-03-12
+### :bug: Bug Fixes
+- [`e4457a1`](https://github.com/nih-sparc/sparc.client/commit/e4457a1e783fdd4bdaad259de5b4e64f271ed20c) - no additional permissions needed, would need to run on vulnerable: pull_request_target *(commit by [@athril](https://github.com/athril))*
+- [`a8b1754`](https://github.com/nih-sparc/sparc.client/commit/a8b17546d4988a2036df66451abb94c85b217740) - code reformatting *(commit by [@athril](https://github.com/athril))*
+- [`0a419f6`](https://github.com/nih-sparc/sparc.client/commit/0a419f6f95b37669c5c8f44fb126c3e6aaae6351) - reformatting back *(commit by [@athril](https://github.com/athril))*
+
+### :wrench: Chores
+- [`2cb1b77`](https://github.com/nih-sparc/sparc.client/commit/2cb1b77e3faca44089f483ad323656b5aa01f985) - expanding CI by adding coverage report *(commit by [@athril](https://github.com/athril))*
+- [`ff59969`](https://github.com/nih-sparc/sparc.client/commit/ff59969313c37a548282e64a0f9e476d77b444a5) - adding protection for sphinx workflow *(commit by [@athril](https://github.com/athril))*
+- [`08683bb`](https://github.com/nih-sparc/sparc.client/commit/08683bb2a0f00f11f0898978e96236ce26f7c479) - an automated pipeline to release new version on Github and PyPI *(commit by [@athril](https://github.com/athril))*
+- [`ee07918`](https://github.com/nih-sparc/sparc.client/commit/ee0791851daea7d0ea0dd48a3db5bfee96fbefaa) - dynamic versioning of PyPI package with setuptools_scm *(commit by [@athril](https://github.com/athril))*
+- [`37431b4`](https://github.com/nih-sparc/sparc.client/commit/37431b42ead4eae38d8adbacafabb78bbb82f292) - fixing PyPI deployment *(commit by [@athril](https://github.com/athril))*
+- [`b485c9e`](https://github.com/nih-sparc/sparc.client/commit/b485c9e6c3d827a9abe1f0f1ab95e981e5ff31aa) - removing commented lines *(commit by [@athril](https://github.com/athril))*
+- [`65e0c75`](https://github.com/nih-sparc/sparc.client/commit/65e0c7528803a3d1292526830574213c1f2b55bd) - limiting scope of Sphinx workflow launch *(commit by [@athril](https://github.com/athril))*
+- [`676b1f9`](https://github.com/nih-sparc/sparc.client/commit/676b1f9f7d34a661c03fd62b0d11fde48a16e938) - adding CODECOV token to prepare for codecov-action@v4 (currently in beta) *(commit by [@athril](https://github.com/athril))*
+- [`7341eae`](https://github.com/nih-sparc/sparc.client/commit/7341eaebf1323a1aa98150038b321d6da190f42b) - fixing reviewdog permissions *(commit by [@athril](https://github.com/athril))*
+- [`4119d2e`](https://github.com/nih-sparc/sparc.client/commit/4119d2ebf0bad418895f505704d3b36da5fb376c) - fixing reviewdog permissions *(commit by [@athril](https://github.com/athril))*
+- [`2afa0eb`](https://github.com/nih-sparc/sparc.client/commit/2afa0eb4ca6260ce1438d6bceb796c7b90a2d6c2) - fixing reviewdog permissions *(commit by [@athril](https://github.com/athril))*
+- [`ea66084`](https://github.com/nih-sparc/sparc.client/commit/ea660848a269fb9b842c2db2e42a0d586ab23886) - reviewdog permissions *(commit by [@athril](https://github.com/athril))*
+- [`b70d867`](https://github.com/nih-sparc/sparc.client/commit/b70d8672d202e25a7b74058a290063c3eb6eef9b) - reviewdog permissions *(commit by [@athril](https://github.com/athril))*
+- [`38cc7c4`](https://github.com/nih-sparc/sparc.client/commit/38cc7c4b730b52e8176f3be17146acb10163d9bc) - fixing outdated versions of actions *(commit by [@athril](https://github.com/athril))*
+
+
 ## [v0.2.0]
 
 ### :sparkles: New features
@@ -65,3 +88,5 @@ Alpha release of Python Sparc Client.
   * listing datasets, files, records
   * downloading files
   * Basic API support (GET/POST)
+
+[v0.3.0]: https://github.com/nih-sparc/sparc.client/compare/v0.2.0...v0.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "sparc.client"
 dynamic = ["version"]
 description = "NIH SPARC Python Client"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.9"
 license = {file = "LICENSE"}
 keywords = ["data science", "datasets"]
 authors = [

--- a/src/sparc/client/client.py
+++ b/src/sparc/client/client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import os
 from configparser import ConfigParser, SectionProxy

--- a/src/sparc/client/services/o2sparc.py
+++ b/src/sparc/client/services/o2sparc.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 import logging
 import os
 from configparser import SectionProxy
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Any, TypeAlias
+from typing import Any, Union
 from zipfile import ZipFile, is_zipfile
 
 import osparc
@@ -11,9 +13,9 @@ from osparc.models.profile import Profile
 
 from ._default import ServiceBase
 
-ConfigDict: TypeAlias = dict[str, Any] | SectionProxy
-UserNameStr: TypeAlias = str
-JobId: TypeAlias = str
+# ConfigDict: TypeAlias = Union[dict[str, Any], SectionProxy]
+# UserNameStr: TypeAlias = str
+# JobId: TypeAlias = str
 
 
 class O2SparcSolver:
@@ -29,7 +31,7 @@ class O2SparcSolver:
         )
         self._jobs: list[osparc.Job] = []
 
-    def submit_job(self, job_inputs: dict[str, str | int | float | Path]) -> JobId:
+    def submit_job(self, job_inputs: dict[str, str | int | float | Path]) -> str:
         """
         Submit a job to the solver/computational service.
 
@@ -59,7 +61,7 @@ class O2SparcSolver:
         self._solvers_api.start_job(self._solver.id, self._solver.version, job.id)
         return job.id
 
-    def get_job_progress(self, job_id: JobId) -> float:
+    def get_job_progress(self, job_id: str) -> float:
         """
         Get the job progress
 
@@ -77,7 +79,7 @@ class O2SparcSolver:
         )
         return float(status.progress / 100)
 
-    def job_done(self, job_id: JobId) -> bool:
+    def job_done(self, job_id: str) -> bool:
         """
         Job done
 
@@ -95,7 +97,7 @@ class O2SparcSolver:
         )
         return not (status.stopped_at is None)
 
-    def get_results(self, job_id: JobId) -> dict[str, Any]:
+    def get_results(self, job_id: str) -> dict[str, Any]:
         """
         Get the results from a job
 
@@ -123,7 +125,7 @@ class O2SparcSolver:
                 results[key] = r
         return results
 
-    def get_job_log(self, job_id: JobId) -> TemporaryDirectory:
+    def get_job_log(self, job_id: str) -> TemporaryDirectory:
         """
         Get the logs from a job
 
@@ -152,7 +154,7 @@ class O2SparcSolver:
 class O2SparcService(ServiceBase):
     """Wraps osparc python client library and fulfills ServiceBase interface"""
 
-    def __init__(self, config: ConfigDict | None = None, connect: bool = True) -> None:
+    def __init__(self, config: dict[str, Any] | SectionProxy | None = None, connect: bool = True) -> None:
         config = config or {}
         logging.info("Initializing o2sparc...")
         logging.debug("%s", f"{config=}")
@@ -187,7 +189,7 @@ class O2SparcService(ServiceBase):
         """Returns the version of osparc client."""
         return self._client.user_agent.split("/")[1]
 
-    def get_profile(self) -> UserNameStr:
+    def get_profile(self) -> str:
         """Returns currently user profile.
 
         Returns:
@@ -198,7 +200,7 @@ class O2SparcService(ServiceBase):
         profile: Profile = users_api.get_my_profile()
         return profile.login
 
-    def set_profile(self, username: str, password: str) -> UserNameStr:
+    def set_profile(self, username: str, password: str) -> str:
         """Changes to a different user profile
 
         Parameters:

--- a/src/sparc/client/services/pennsieve.py
+++ b/src/sparc/client/services/pennsieve.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import logging
-import os
 
 import requests
 from pennsieve2 import Pennsieve
@@ -348,7 +349,7 @@ class PennsieveService(ServiceBase):
         -----------
         url : str
             The address of the server endpoint to be called (e.g. api.pennsieve.io/datasets).
-            The name of the server can be ommitted.
+            The name of the server can be omitted.
         kwargs : dict
             A dictionary storing additional information.
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,8 +1,6 @@
 import json
 import os
 
-import pytest
-
 from sparc.client import SparcClient
 
 test_dir = os.path.dirname(__file__)
@@ -12,10 +10,10 @@ config_file = os.path.join(config_dir, "config.ini")
 
 # Test client initialization
 def test_metadata_connect_false():
-    client = SparcClient(connect=False, config_file=config_file)
+    client1 = SparcClient(connect=False, config_file=config_file)
 
-    response = client.metadata.info()
-    client.metadata.close()
+    response = client1.metadata.info()
+    client1.metadata.close()
     assert response == "https://api.scicrunch.io/elastic/v1"
 
 
@@ -39,8 +37,6 @@ def test_metadata_info():
 
 # Test list datasets with no API key
 def test_metadata_search_datasets_nokey():
-    response = {}
-
     response = client.metadata.list_datasets()
     print("No Header: " + str(response) + " :End")
 
@@ -112,7 +108,7 @@ def test_metadata_api_key():
 # Test get URL with no headers
 def test_metadata_get_noheader():
     get_result = client.metadata.getURL(
-        "https://api.scicrunch.io/elastic/v1/SPARC_Algolia_pr/_search", headers="NONE"
+        "https://api.scicrunch.io/elastic/v1/SPARC_Algolia_pr/_search", headers=None
     )
 
     if get_result["status"] >= 400:
@@ -127,7 +123,7 @@ def test_metadata_post_noheader():
     body_json = json.loads(body)
 
     post_result = client.metadata.postURL(
-        "https://api.scicrunch.io/elastic/v1/SPARC_Algolia_pr/_search", body_json, headers="NONE"
+        "https://api.scicrunch.io/elastic/v1/SPARC_Algolia_pr/_search", body_json, headers=None
     )
     print(str(post_result))
     if post_result["status"] >= 400:
@@ -152,4 +148,4 @@ def test_metadata_search_badbody():
 # Test close
 def test_metadata_close():
     close_result = client.metadata.close()
-    assert close_result == "https://api.scicrunch.io/elastic/v1"
+    assert close_result is None


### PR DESCRIPTION
Some of the other tools in the SPARC sphere are still using Python 3.9. These changes allows those tools to make use of this library.